### PR TITLE
Fix/rss feed link fix

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,58 @@
+# Pull Request
+
+## Description
+<!-- Provide a clear and concise description of the changes introduced in this PR -->
+
+## Related Issue (if applicable)
+<!-- Link to the issue this PR addresses if applicable. Remove if not. Use format: Fixes #123 or Relates to #123 -->
+
+## Type of Change
+<!-- Mark the relevant option with an 'x' (no spaces around x) -->
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Performance improvement
+- [ ] UI/UX enhancement
+
+## Implementation Details
+<!-- Explain the key technical decisions and approach taken to implement the changes -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your changes -->
+
+## Testing
+<!-- Describe the tests you ran to verify your changes -->
+
+### Automated Tests
+<!-- List any new or modified automated tests -->
+
+### Manual Testing Steps
+<!-- Steps to manually verify the changes work as expected -->
+
+## Performance Impact
+<!-- Describe any performance impacts (positive or negative) -->
+
+## Accessibility Considerations
+<!-- Describe how accessibility requirements have been addressed -->
+
+## Database Changes
+<!-- Describe any changes to database schema or migrations required -->
+
+## Deployment Notes
+<!-- Include any special deployment instructions or dependencies -->
+
+## Checklist
+<!-- Mark completed items with an 'x' (no spaces around x) -->
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Additional Notes
+<!-- Any other information that is important to this PR -->

--- a/app/templates/blog/rss.xml
+++ b/app/templates/blog/rss.xml
@@ -15,8 +15,8 @@
         {% else %}
         <description><![CDATA[{{ post.content | truncate(400) }}]]></description>
         {% endif %}
-        <link>{{ request.base_url }}post/{{ post.slug }}</link>
-        <guid>{{ request.base_url }}post/{{ post.slug }}</guid>
+        <link>{{ request.base_url }}blog/{{ post.slug }}</link>
+        <guid>{{ request.base_url }}blog/{{ post.slug }}</guid>
         <pubDate>{{ post.created_at.strftime('%a, %d %b %Y %H:%M:%S GMT') }}</pubDate>
     </item>
     {% endfor %}

--- a/tests/unit/routers/conftest.py
+++ b/tests/unit/routers/conftest.py
@@ -78,7 +78,7 @@ def mock_post(db_session):
         is_page=False,
         created_at=datetime.now(),
         updated_at=datetime.now(),
-        meta_description="",
+        meta_description="Test post meta description",
     )
     db_session.add(post)
     db_session.commit()

--- a/tests/unit/routers/test_blog_router.py
+++ b/tests/unit/routers/test_blog_router.py
@@ -52,6 +52,11 @@ def test_rss_feed_enabled(client, mock_post, mock_settings):
     assert response.status_code == status.HTTP_200_OK
     assert "application/xml" in response.headers["content-type"]
     assert mock_post.title in response.text
+    assert mock_settings.blog_title in response.text
+    assert mock_settings.blog_description in response.text
+    assert mock_post.title in response.text
+    assert mock_post.meta_description in response.text
+    assert f"<link>http://testserver/blog/{mock_post.slug}</link>" in response.text
 
 
 def test_rss_feed_disabled(client, mock_settings):


### PR DESCRIPTION
# Pull Request

## Description
- Fixes the issue where the RSS feed template was using the wrong URL for blog posts
## Type of Change
<!-- Mark the relevant option with an 'x' (no spaces around x) -->
- [x] Bug fix (non-breaking change that fixes an issue)


## Testing
Visited the RSS feed endpoint, confirmed the URL directs to the correct blog post

### Automated Tests
Added tests to better check for the content in the RSS feed XML

## Checklist
<!-- Mark completed items with an 'x' (no spaces around x) -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published