### PR TITLE
Fix media preview missing the /media prefix in the urls

### DIFF
--- a/app/templates/admin/media.html
+++ b/app/templates/admin/media.html
@@ -493,7 +493,7 @@
         .then(media => {
           let mediaPreview = '';
           if (media.mime_type.startsWith('image/')) {
-            mediaPreview = `<img src="${media.medium_path}" alt="${media.original_filename}">`;
+            mediaPreview = `<img src="/media/${media.medium_path}" alt="${media.original_filename}">`;
           } else {
             mediaPreview = `
               <div class="media-placeholder large">
@@ -540,8 +540,8 @@
                 <div class="media-usage-title">Markdown</div>
                 <div class="media-usage-code">
                   ${media.mime_type.startsWith('image/') ?
-              `![/media/${media.original_filename}](${media.medium_path})` :
-              `[/media/${media.original_filename}](${media.file_path})`}
+              `![/media/${media.original_filename}](/media/${media.medium_path})` :
+              `[/media/${media.original_filename}](/media/${media.file_path})`}
                 </div>
               </div>
             </div>
@@ -559,9 +559,9 @@
         .then(media => {
           let markdownCode = '';
           if (media.mime_type.startsWith('image/')) {
-            markdownCode = `![${media.original_filename}](${media.medium_path})`;
+            markdownCode = `![${media.original_filename}](/media/${media.medium_path})`;
           } else {
-            markdownCode = `[${media.original_filename}](${media.file_path})`;
+            markdownCode = `[${media.original_filename}](/media/${media.file_path})`;
           }
 
           localStorage.setItem('postlite-media-insert', markdownCode);


### PR DESCRIPTION
# Pull Request

## Description
Fixes an issue in the media management UI where the image preview and markdown copy didn't include the `/media` prefix it was supposed to have, leading to a 404

## Related Issue (if applicable)
Fixes #13 

## Type of Change
<!-- Mark the relevant option with an 'x' (no spaces around x) -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] UI/UX enhancement

## Screenshots
<img width="1314" height="519" alt="image" src="https://github.com/user-attachments/assets/52efa310-d946-49d3-8d7c-eeb406b2182f" />



## Testing
Used the copied text in a post to verify the image would load

## Checklist
<!-- Mark completed items with an 'x' (no spaces around x) -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published
